### PR TITLE
Finesse ligatures to work with Adobe Acrobat Reader search and cut-and-paste

### DIFF
--- a/texsrc/bitmanip.tex
+++ b/texsrc/bitmanip.tex
@@ -1,5 +1,9 @@
 \documentclass[twoside,11pt]{book}
 
+% Fix copy/pasting of ligatures in Acrobat
+\input{glyphtounicode.tex}
+\pdfgentounicode=1 %
+
 \input{preamble}
 \usepackage[nottoc,notlot,notlof]{tocbibind}
 \usepackage[normalem]{ulem}


### PR DESCRIPTION
This is the same fundamental change for the same observed problem as the base ISA and debug spec:
riscv/riscv-isa-manual#370
riscv/riscv-debug-spec#442

> Adobe Acrobat Reader DC 19.010.20099 for Windows doesn't work well with the ligatures found in the RISC-V specs. Searching for words like "defined" doesn't work due to the "fi" ligature. Copying "defined" to the clipboard will drop the "fi" and only copy "dened" (or there's possibly an unprintable character there).
> 
> Other PDF viewers seem to have better behavior than the Adobe product (which is odd since Adobe invented PDF). However, enough people use Acrobat that it ought to be supported if possible.
> 
> I found a fix for this situation on:
> https://superuser.com/questions/165073/is-it-possible-to-remove-ligatures-from-copied-text
> Ligatures appear to be rendered the same after the fix, so there's no visual difference. I tried viewing and searching using evince on Linux and it works as before. But searching and clipboard operations on Adobe Acrobat Reader now work as expected with this change.