### PR TITLE
remove "a" to fix grammar in intro

### DIFF
--- a/texsrc/intro.tex
+++ b/texsrc/intro.tex
@@ -15,7 +15,7 @@ criteria.
   not re-implement features that are already found in the base
   specification or other extensions.
 \item
-  Threshold Metric: The proposal should provide a \emph{significant}
+  Threshold Metric: The proposal should provide \emph{significant}
   savings in terms of clocks or instructions. As a heuristic, any
   proposal should replace at least three instructions. An instruction
   that only replaces two may be considered, but only if the frequency


### PR DESCRIPTION
Hi, this is a wonderful repository!

I do believe that the grammar of "provide a \emph{significant} savings in terms" is incorrect and thus I have
removed the word "a" in an attempt to bring about correctness.

Alternatively, we could replace "savings" with "saving" to give "provide a \emph{significant} saving in terms".

I may of course be wrong - please forgive me if so 🤷‍♂ 