### PR TITLE
Use new CRC instruction names.

### DIFF
--- a/texsrc/bext.tex
+++ b/texsrc/bext.tex
@@ -964,9 +964,9 @@ and perform a polynomial reduction of that state shifted left by 8, 16, 32, or
 
 The instructions return the new CRC32/CRC32C state.
 
-The \texttt{crc32w}/\texttt{crc32cw} instructions are equivalent to executing
-\texttt{crc32h}/\texttt{crc32ch} twice, and \texttt{crc32h}/\texttt{crc32ch}
-instructions are equivalent to executing \texttt{crc32b}/\texttt{crc32cb}
+The \texttt{crc32.w}/\texttt{crc32c.w} instructions are equivalent to executing
+\texttt{crc32.h}/\texttt{crc32c.h} twice, and \texttt{crc32.h}/\texttt{crc32c.h}
+instructions are equivalent to executing \texttt{crc32.b}/\texttt{crc32c.b}
 twice.
 
 All 8 CRC instructions operate on bit-reflected data.


### PR DESCRIPTION
Minor change to use the correct CRC instruction names.