### PR TITLE
Clarify immediate widths for sbseti/sbclri/sbinvi/sbexti.

### DIFF
--- a/texsrc/bext.tex
+++ b/texsrc/bext.tex
@@ -1706,7 +1706,8 @@ encoding scheme used for {\tt add} and {\tt sub}.
 All shift instructions use {\tt funct3=001} for left shifts and {\tt funct3=101}
 for right shifts. Just like in the RISC-V integer base ISA, the shift-immediate
 instructions have a 5 bit immediate on RV32, and a 6 bit immediate on RV64, and we
-reserve encoding space for a 7 bit immediate for RV128.
+reserve encoding space for a 7 bit immediate for RV128.  The same sizes apply
+to {\tt sbseti}, {\tt sbclri}, {\tt sbinvi}, and {\tt sbexti}.
 
 The immediate for {\tt shfli}/{\tt unshufli} is one bit smaller than the immediate
 for shift instructions, that is 4 bits on RV32, 5 bits on RV64, and we reserve 6


### PR DESCRIPTION
Proposed text to answer my own question: https://lists.riscv.org/g/tech-bitmanip/message/77
