### PR TITLE
Explicitly declare zba, zbb and zbc are frozen

### DIFF
--- a/texsrc/bext.tex
+++ b/texsrc/bext.tex
@@ -76,7 +76,7 @@ B
  & \multicolumn{2}{l}{All of the above except Zbr and Zbt} \\
 \hline
 Notes:\\
-\multicolumn{3}{l}{- * means the extensions are expected to be unchanged in the official version.} \\
+\multicolumn{3}{l}{- * means the extensions are frozen since v0.93 which means that expected to be unchanged in the official version.} \\
 \end{tabular}
 \caption{{\tt Zb*} extensions instruction listings}
 \end{center}


### PR DESCRIPTION
I think having explicit frozen word in the spec would be great, even the original text is kind of equivalence to frozen. 