### PR TITLE
Correct riscv ovpsim info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,25 @@ The [cproofs](cproofs) directory contains the reference C models and a few relat
 
 ----
 
-# Imperas riscvOVPsim Reference Simulation
-**riscvOVPsim** was created by Imperas in 2018 to assist in the development of compliance tests and to provide a free, high quality, configurable reference simulator of the RISC-V specifications.
+# Imperas riscvOVPsimPlus Free Reference Simulation
+
+**riscvOVPsimPlus** is an extension to **riscvOVPsim** created by Imperas in 2018 to assist in the development of compliance tests and to provide a free, high quality, configurable reference simulator of the RISC-V specifications.
 
 It is developed by Imperas and is kept up to date as the Bit Manip extensions changes and moves to standardization.
 
 It was originally provided in this repository as a convenience. It has now evolved and has been enhanced and moved to its own repository.
 
-There are now two flavors: _riscvOVPsim_ from [github.com/riscv-ovpsim](https://github.com/riscv-ovpsim/imperas-riscv-tests) which is useful for running compliance tests and generating the required signatures, and _riscvOVPsimPlus_ from [ovpworld.org/riscv-ovpsim-plus](https://www.ovpworld.org/riscv-ovpsim-plus) which is used for test development and verification.
+There are now two flavors:  _riscvOVPsim_  from [github.com/riscv-ovpsim](https://github.com/riscv-ovpsim/imperas-riscv-tests) which supports standard and ratified extensions and is useful for running compliance tests and generating the required signatures, and  _riscvOVPsimPlus_  from [ovpworld.org/riscv-ovpsim-plus](https://www.ovpworld.org/riscv-ovpsim-plus) which supports additional features and all extension, including those not yet ratified, is used for test development and verification.
 
 Please contact info@ovpworld.org or info@imperas.com for more information.
 
-For details on riscvOVPsim look here: [github.com/riscv-ovpsim](https://github.com/riscv-ovpsim/imperas-riscv-tests) and here: [riscv-ovpsim/doc/riscvOVPsim_User_Guide.pdf](https://github.com/riscv-ovpsim/imperas-riscv-tests/blob/main/riscv-ovpsim/doc/riscvOVPsim_User_Guide.pdf).
+For details on riscvOVPsim look here: [github.com/riscv-ovpsim](https://github.com/riscv-ovpsim/imperas-riscv-tests) and here: [riscv-ovpsim/doc/riscvOVPsim_User_Guide.pdf](https://github.com/riscv-ovpsim/imperas-riscv-tests/blob/master/riscv-ovpsim/doc/riscvOVPsim_User_Guide.pdf).
 
-To enable the new it manip extension/instructions, enable the B bit in the MISA register
+For details on riscvOVPsimPlus look here: [riscv-ovpsim/doc/riscvOVPsimPlus_User_Guide.pdf](https://github.com/riscv-ovpsim/imperas-riscv-tests/blob/master/riscv-ovpsim-plus/doc/riscvOVPsimPlus_User_Guide.pdf).
 
-    riscvOVPsim.exe --override riscvOVPsim/cpu/add_Extensions=B
+To enable the bit manip extension/instructions, enable the B bit in the MISA register
+
+    riscvOVPsimPlus.exe --override riscvOVPsim/cpu/add_Extensions=B
 
 And in the log you will see it enabled, for example:
 

--- a/riscv-ovpsim/README.md
+++ b/riscv-ovpsim/README.md
@@ -27,7 +27,7 @@ The simulator is command line configurable to enable/disable all current optiona
 
 The simulator is developed, licensed and maintained by [Imperas Software](http://www.imperas.com/riscv) and it is fully compliant to the OVP open standard APIs. 
 
-As a member of the RISC-V Foundation community of software and hardware innovators collaboratively driving RISC-V adoption, Imperas has developed the riscvOVPsim simulators to assist RISC-V adopters to become compliant to the RISC-V specifications. The latest RISC-V compliance test suite and framework can be downloaded from https://www.github.com/riscv/riscv-compliance. 
+As a member of the RISC-V Foundation community of software and hardware innovators collaboratively driving RISC-V adoption, Imperas has developed the riscvOVPsim simulators to assist RISC-V adopters to become compliant to the RISC-V specifications. The latest RISC-V compliance test suite and framework can be downloaded from [github.com/riscv/riscv-arch-test](https://www.github.com/riscv/riscv-arch-test). 
 
 riscvOVPsim and riscvOVPsimPlus include an industrial quality model and simulator of RISC-V processors for use for compliance and test development. It has been developed for personal, academic, or commercial use, and the model is provided as open source under the Apache 2.0 license. The simulator is provided under the  Open Virtual Platforms (OVP) Fixed Platform Kits license that enables download and usage. riscvOVPsim and Imperas RISC-V support is actively maintained and enhanced. To ensure you make use of the current version of riscvOVPsim versions do expire. Please download the latest version.
 

--- a/riscv-ovpsim/README.md
+++ b/riscv-ovpsim/README.md
@@ -1,29 +1,42 @@
+riscvOVPsim / riscvOVPsimPlus
+===
+Complete, Fully Functional, Configurable RISC-V Simulators
+===
+
+riscvOVPsim has been split into two separate executable simulators; riscvOVPsim and riscvOVPsimPlus
+
+
 riscvOVPsim
-===
-A Complete, Fully Functional, Configurable RISC-V Simulator
-===
+---
+riscvOVPsim supports the RISC-V Foundation's public User and Privilege specifications, including all standard and ratified extensions i.e. I E M A F D C S U N.
 
-riscvOVPsim has moved to its own GitHub repository.
+riscvOVPsim has moved to its own GitHub repository. It can now be found here: [github.com/riscv-ovpsim](https://github.com/riscv-ovpsim/imperas-riscv-tests)
 
-It can now be found here: [github.com/riscv-ovpsim](https://github.com/riscv-ovpsim/imperas-riscv-tests)
+riscvOVPsimPlus
+---
+riscvOVPsimPlus extends the functionality of riscvOVPsim and provides many more features including full configurable instruction trace, GDB/Eclipse debug, and memory configuration options. Additionally in the model are: CLIC, Debug Module/Mode, multi-hart, H-hypervisor simulation, and also 'near-ratified' ISA extensions: V-vector, B-bitmanip, K-crypto(scalar).
 
-For the enhanced version, please download from [ovpworld.org/riscv-ovpsim-plus](https://www.ovpworld.org/riscvOVPsimPlus).
+riscvOVPsimPlus can be downloaded from [ovpworld.org/riscv-ovpsim-plus](https://www.ovpworld.org/riscvOVPsimPlus).
 
+
+Introduction
+---
 The simulators implement the full and complete functionality of the RISC-V Foundation's public User and Privilege specifications.  
 
 The simulator is command line configurable to enable/disable all current optional and processor specific options. 
 
 The simulator is developed, licensed and maintained by [Imperas Software](http://www.imperas.com/riscv) and it is fully compliant to the OVP open standard APIs. 
 
-As a member of the RISC-V Foundation community of software and hardware innovators collaboratively driving RISC-V adoption, Imperas has developed the riscvOVPsim simulator to assist RISC-V adopters to become compliant to the RISC-V specifications. The latest RISC-V compliance test suite and framework can be downloaded from https://www.github.com/riscv/riscv-compliance. 
+As a member of the RISC-V Foundation community of software and hardware innovators collaboratively driving RISC-V adoption, Imperas has developed the riscvOVPsim simulators to assist RISC-V adopters to become compliant to the RISC-V specifications. The latest RISC-V compliance test suite and framework can be downloaded from https://www.github.com/riscv/riscv-compliance. 
 
-riscvOVPsim includes an industrial quality model and simulator of RISC-V processors for use for compliance and test development. It has been developed for personal, academic, or commercial use, and the model is provided as open source under the Apache 2.0 license. The simulator is provided under the  Open Virtual Platforms (OVP) Fixed Platform Kits license that enables download and usage. riscvOVPsim and Imperas RISC-V support is actively maintained and enhanced. To ensure you make use of the current version of riscvOVPsim versions do expire. Please download the latest version.
+riscvOVPsim and riscvOVPsimPlus include an industrial quality model and simulator of RISC-V processors for use for compliance and test development. It has been developed for personal, academic, or commercial use, and the model is provided as open source under the Apache 2.0 license. The simulator is provided under the  Open Virtual Platforms (OVP) Fixed Platform Kits license that enables download and usage. riscvOVPsim and Imperas RISC-V support is actively maintained and enhanced. To ensure you make use of the current version of riscvOVPsim versions do expire. Please download the latest version.
 
 ![](riscvOVPsim.jpg)  
 
-Extending riscvOVPsim and building your own models and platforms
+
+Extending and building your own models and platforms
 ---
-riscvOVPsim is a fixed function simulation of one configurable processor model in a fixed platform. 
+riscvOVPsim and riscvOVPsimPlus are fixed function simulation of one configurable processor model in a fixed platform. 
 Full extendable platform simulations of reference designs booting FreeRTOS, Linux, SMP Linux etc. 
 are available as open source and are available from [www.IMPERAS.com](http://www.imperas.com), 
 [www.OVPworld.org](http://www.OVPworld.org).  

--- a/riscv-ovpsim/README.md
+++ b/riscv-ovpsim/README.md
@@ -36,7 +36,7 @@ riscvOVPsim and riscvOVPsimPlus include an industrial quality model and simulato
 
 Extending and building your own models and platforms
 ---
-riscvOVPsim and riscvOVPsimPlus are fixed function simulation of one configurable processor model in a fixed platform. 
+riscvOVPsim and riscvOVPsimPlus are free to use and provide fixed function simulation of one configurable processor model in a fixed platform. 
 Full extendable platform simulations of reference designs booting FreeRTOS, Linux, SMP Linux etc. 
 are available as open source and are available from [www.IMPERAS.com](http://www.imperas.com), 
 [www.OVPworld.org](http://www.OVPworld.org).  


### PR DESCRIPTION
Some of the information on how to obtain and execute using riscvOVPsim was out of date and required updating so stop confusion that users were finding when attempting to run bit-manipulation instructions