### PR TITLE
Put Bitwise rotate section back under Zbb section

### DIFF
--- a/bitmanip/_rotate.adoc
+++ b/bitmanip/_rotate.adoc
@@ -1,4 +1,4 @@
-=== Bitwise rotation
+==== Bitwise rotation
 
 Bitwise rotation instructions are similar to the shift-logical operations from the base spec. However, where the shift-logical 
 instructions shift in zeros, the rotate instructions shift in the bits that were shifted out of the other side of the value.


### PR DESCRIPTION
This got changed after 0.94.60 but doesn't look right since "OR combine" and "Byte-reverse" are currently nested under "Bitwise rotate"