### PR TITLE
changing reference to sub-extension to extension

### DIFF
--- a/bitmanip/zba.adoc
+++ b/bitmanip/zba.adoc
@@ -10,7 +10,7 @@ The Zba instructions can be used to accelerate the generation of addresses that 
 
 The shift and add instructions do a left shift of 1, 2, or 3 because these are commonly found in real-world code and because they can be implemented with a minimal amount of additional hardware beyond that of the simple adder. This avoids lengthening the critical path in implementations.
 
-While the shift and add instructions are limited to a maximum left shift of 3, the slli instruction (from the base ISA) can be used to perform similar shifts for indexing into arrays of wider elements. The slli.uw -- added in this sub extension -- can be used when the index is to be interpreted as an unsigned word.
+While the shift and add instructions are limited to a maximum left shift of 3, the slli instruction (from the base ISA) can be used to perform similar shifts for indexing into arrays of wider elements. The slli.uw -- added in this extension -- can be used when the index is to be interpreted as an unsigned word.
 
 The following instructions comprise the Zba extension:
 


### PR DESCRIPTION
There aren't sub-extensions anymore, right?  just extensions?
"Lastly, note that it has been declared that there will only be "extensions" - not extensions and sub-extensions. "  Tech chairs email 6/7/2021