### PR TITLE
rolw: fix signextension in sail code

### DIFF
--- a/bitmanip/insns/rolw.adoc
+++ b/bitmanip/insns/rolw.adoc
@@ -30,7 +30,7 @@ Operation::
 let rs1 = EXTZ(X(rs1)[31..0])
 let shamt = X(rs2)[4..0];
 let result = (rs1 << shamt) | (rs1 >> (32 - shamt));
-X(rd) = EXTS(result);
+X(rd) = EXTS(result[31..0]);
 --
 
 Included in::


### PR DESCRIPTION
The fix is also consistent with the definition in Spike.
https://github.com/riscv/riscv-isa-sim/blob/master/riscv/insns/rolw.h

```
require_rv64;
require_extension(EXT_ZBB);
int shamt = RS2 & 31;
int rshamt = -shamt & 31;
WRITE_RD(sext32((RS1 << shamt) | (zext32(RS1) >> rshamt)));
```