### PR TITLE
clmul: fix loop-end condition in the sail code

### DIFF
--- a/bitmanip/insns/clmul.adoc
+++ b/bitmanip/insns/clmul.adoc
@@ -30,7 +30,7 @@ let rs1_val = X(rs1);
 let rs2_val = X(rs2);
 let output : xlenbits = 0;
 
-foreach (i from 0 to xlen by 1) {
+foreach (i from 0 to (xlen - 1) by 1) {
    output = if   ((rs2_val >> i) & 1)
             then output ^ (rs1_val << i);
 	    else output;


### PR DESCRIPTION
Although the last iteration does not affect on the output, it is redundant.

```
xlen:32

  + 32: 31 30 29 ... 02 01 00
+ | 31:    31 30 29 ... 02 01 00
| |                 .
| |                 XOR
| |                 .
| + 01:                    31 30 29 ... 02 01 00
+   00:                       31 30 29 ... 02 01 00
        |<---  clmulh   --->| |<---   clmul   --->|
           |<---  clmulr   --->|

clmul:  0 to (xlen – 1)
clmulh: 1 to  xlen
clmulr: 0 to (xlen – 1)
```