### PR TITLE
roriw: remove redundant bit range

### DIFF
--- a/bitmanip/insns/roriw.adoc
+++ b/bitmanip/insns/roriw.adoc
@@ -32,7 +32,7 @@ Operation::
 [source,sail]
 --
 let rs1_data = EXTZ(X(rs1)[31..0];
-let result = (rs1_data >> shamt[4..0]) | (rs1_data << (32 - shamt[4..0]));
+let result = (rs1_data >> shamt) | (rs1_data << (32 - shamt));
 X(rd) = EXTS(result[31..0]);
 --
 


### PR DESCRIPTION
Fix to be consistent with the Sail code for rorw and slli.uw.