### PR TITLE
zext.w: Add pseudoinstruction to instruction tables

### DIFF
--- a/bitmanip/overview.adoc
+++ b/bitmanip/overview.adoc
@@ -438,4 +438,13 @@ along with their specific mapping:
 |
 |
 
+|
+|&#10003;
+|zext.w _rd_, _rs_
+|<<#insns-add_uw>>
+|&#10003;
+|
+|
+|
+
 |====

--- a/bitmanip/zba.adoc
+++ b/bitmanip/zba.adoc
@@ -12,7 +12,7 @@ The shift and add instructions do a left shift of 1, 2, or 3 because these are c
 
 While the shift and add instructions are limited to a maximum left shift of 3, the slli instruction (from the base ISA) can be used to perform similar shifts for indexing into arrays of wider elements. The slli.uw -- added in this extension -- can be used when the index is to be interpreted as an unsigned word.
 
-The following instructions comprise the Zba extension:
+The following instructions (and pseudoinstructions) comprise the Zba extension:
 
 [%header,cols="^1,^1,4,8"]
 |===
@@ -60,6 +60,11 @@ The following instructions comprise the Zba extension:
 |&#10003;
 |slli.uw _rd_, _rs1_, _imm_
 |<<#insns-slli_uw>>
+
+|
+|&#10003;
+|zext.w _rd_, _rs_
+|<<#insns-add_uw>>
 
 |===
 


### PR DESCRIPTION
The table in chapter 1 claims to contain "a list of all of the instructions (and pseudo instructions)".
However, the pseudo instruction `zext.w` is missing there. Also, the instruction table of Zba is missing `zext.w`.
This PR has two commits to add the instruction to the table.