### PR TITLE
sh3add _rd_, _rs2_, _rs2_ -> sh3add _rd_, _rs1_, _rs2_

### DIFF
--- a/bitmanip/overview.adoc
+++ b/bitmanip/overview.adoc
@@ -395,7 +395,7 @@ along with their specific mapping:
 
 |&#10003;
 |&#10003;
-|sh3add _rd_, _rs2_, _rs2_
+|sh3add _rd_, _rs1_, _rs2_
 |<<#insns-sh3add>>
 |&#10003;
 |


### PR DESCRIPTION
Commit 18256715e60ebd67b17d2104bf5e458527aab89f  already fixed this typo in zba.adoc, but it was still there in the global table.