### PR TITLE
Typo fix "indic[i]es" -> "indices"

### DIFF
--- a/bitmanip/insns/xpermb.adoc
+++ b/bitmanip/insns/xpermb.adoc
@@ -2,7 +2,7 @@
 === xperm.b
 
 Synopsis::
-Byte-wise lookup of indicies into a vector in registers.
+Byte-wise lookup of indices into a vector in registers.
 
 Mnemonic::
 xperm.b _rd_, _rs1_, _rs2_

--- a/bitmanip/insns/xpermn.adoc
+++ b/bitmanip/insns/xpermn.adoc
@@ -2,7 +2,7 @@
 === xperm.n
 
 Synopsis::
-Nibble-wise lookup of indicies into a vector.
+Nibble-wise lookup of indices into a vector.
 
 Mnemonic::
 xperm.n _rd_, _rs1_, _rs2_

--- a/bitmanip/zbkx.adoc
+++ b/bitmanip/zbkx.adoc
@@ -9,7 +9,7 @@ The Zbkx extension is frozen.
 These instructions implement a "lookup table" for 4 and 8 bit elements
 inside the general purpose registers.
 _rs1_ is used as a vector of N-bit words, and _rs2_ as a vector of N-bit
-indicies into _rs1_.
+indices into _rs1_.
 Elements in _rs1_ are replaced by the indexed element in _rs2_, or zero
 if the index into _rs2_ is out of bounds.
 


### PR DESCRIPTION
Trivial change. The plural of "index" is "indices". One instance
in zba.adoc was already correctly spelled.

Signed-off-by: Eric Gouriou <ego@rivosinc.com>