### PR TITLE
insn is I-type, opcode should be OP-IMM[-32] for zext.h

### DIFF
--- a/bitmanip/insns/zext_h.adoc
+++ b/bitmanip/insns/zext_h.adoc
@@ -11,7 +11,7 @@ Encoding (RV32)::
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  7, name: 0x33, attr: ['OP'] },
+    { bits:  7, name: 0x13, attr: ['OP-IMM'] },
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x4, attr: ['ZEXT.H']},
     { bits:  5, name: 'rs' },
@@ -24,7 +24,7 @@ Encoding (RV64)::
 [wavedrom, , svg]
 ....
 {reg:[
-    { bits:  7, name: 0x3b, attr: ['OP-32'] },
+    { bits:  7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x4, attr: ['ZEXT.H']},
     { bits:  5, name: 'rs' },


### PR DESCRIPTION
Instructions with bits [24:20] as immediate or function values are I-type. Instructions with bits [24:20] as registers (like rs2) are R-type. Shouldn't zext.b be an I-type instruction, with opcode OP-IMM or 0x13?

Signed-off-by: Paul Sherman <36460742+psherman42@users.noreply.github.com>