### PR TITLE
show opcode as 7-bits like all other insn for unzip and zip

### DIFF
--- a/bitmanip/insns/unzip.adoc
+++ b/bitmanip/insns/unzip.adoc
@@ -11,8 +11,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 2, name: 0x3},
-{bits: 5, name: 0x4},
+{bits: 7, name: 0x13, attr: ['OP-IMM']},
 {bits: 5, name: 'rd'},
 {bits: 3, name: 0x5},
 {bits: 5, name: 'rs1'},

--- a/bitmanip/insns/zip.adoc
+++ b/bitmanip/insns/zip.adoc
@@ -12,8 +12,7 @@ Encoding::
 [wavedrom, , svg]
 ....
 {reg:[
-{bits: 2, name: 0x3},
-{bits: 5, name: 0x4},
+{bits: 7, name: 0x13, attr: ['OP-IMM']},
 {bits: 5, name: 'rd'},
 {bits: 3, name: 0x1},
 {bits: 5, name: 'rs1'},


### PR DESCRIPTION
[ 00100 ][ 11 ] should be written as [ 0010011 ] (0x13) or OP-IMM to be consistent with all other instructions.

Also, in the **Operations** section, should one of the _foreach_ loops between `unzip` and `zip` be different like, for example,
```
foreach(i from 0 to xlen/2-1) {
    x(rd)[i] = X(rs1)[2*i]
    x(rd)[2*i+1] = X(rs1)[i+xlen/1]
}
```