### PR TITLE
strlen: Replace PTRLOG with explicit 3

### DIFF
--- a/bitmanip/software-guide/strlen.adoc
+++ b/bitmanip/software-guide/strlen.adoc
@@ -20,7 +20,7 @@ strlen:
 .Lprologue:
 	li      a4, SZREG
 	sub     a4, a4, a3          // XLEN - offset
-	slli	a3, a3, PTRLOG      // offset * 8
+	slli	a3, a3, 3           // offset * 8
 	REG_L   a2, 0(a1)           // chunk
 	/*
 	 * Shift the partial/unaligned chunk we loaded to remove the bytes


### PR DESCRIPTION
The shift immediate should be 3, even for rv32, since we want log(bits-per-byte), not log(bytes-per-word). PTRLOG implies log(bytes-per-word), so replace it with an explicit 3 as is used elsewhere in the example when log(bits-per-byte) is needed.